### PR TITLE
Remove .gif blacklisting

### DIFF
--- a/lib/meta_inspector/parsers/images.rb
+++ b/lib/meta_inspector/parsers/images.rb
@@ -103,7 +103,7 @@ module MetaInspector
       end
 
       def blacklist
-        Regexp.union 'banner', 'background', 'empty', 'sprite', 'base64', '.gif', '.tiff'
+        Regexp.union 'banner', 'background', 'empty', 'sprite', 'base64', '.tiff'
       end
 
     end


### PR DESCRIPTION
Can we remove .gif from blacklist? Sometimes the best image has .gif extension, but not animated, like on this page - http://www.fivefingertees.com/dont-hassle-me-im-local-t-shirt.html
